### PR TITLE
Make it compatible with `gulp-reporter` & `gulp-eslint`

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -5,4 +5,6 @@ const xo = require('.');
 gulp.task('default', () =>
 	gulp.src('_fixture.js')
 		.pipe(xo())
+		.pipe(xo.format())
+		.pipe(xo.failAfterError())
 );

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
 'use strict';
+const eslint = require('gulp-eslint');
 const gutil = require('gulp-util');
 const through = require('through2');
 const xo = require('xo');
@@ -7,10 +8,6 @@ module.exports = opts => {
 	opts = Object.assign({
 		quiet: false
 	}, opts);
-
-	let results = [];
-	let errorCount = 0;
-	let warningCount = 0;
 
 	return through.obj(function (file, enc, cb) {
 		if (file.isNull()) {
@@ -40,23 +37,10 @@ module.exports = opts => {
 			result = xo.getErrorResults(result);
 		}
 
-		errorCount += report.errorCount;
-		warningCount += report.warningCount;
-
-		results.push(result);
+		file.eslint = result[0];
 
 		cb(null, file);
-	}, function (cb) {
-		results = results.reduce((a, b) => a.concat(b), []);
-
-		if (errorCount > 0 || warningCount > 0) {
-			gutil.log('gulp-xo\n', xo.getFormatter(opts.reporter)(results));
-		}
-
-		if (errorCount > 0) {
-			this.emit('error', new gutil.PluginError('gulp-xo', `${errorCount} errors`));
-		}
-
-		cb();
 	});
 };
+
+Object.assign(module.exports, eslint);

--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const eslint = require('gulp-eslint');
+const formatterPretty = require('eslint-formatter-pretty');
 const gutil = require('gulp-util');
 const through = require('through2');
 const xo = require('xo');
@@ -44,3 +45,9 @@ module.exports = opts => {
 };
 
 Object.assign(module.exports, eslint);
+
+['formatEach', 'format'].forEach(fn => {
+	module.exports[fn] = (formatter, writable) => (
+		eslint[fn](formatter ? xo.getFormatter(formatter) : formatterPretty, writable)
+	);
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "test": "xo --ignore _fixture.js && ava"
+    "test": "xo --ignore='_fixture.js' && ava"
   },
   "files": [
     "index.js"
@@ -48,6 +48,7 @@
     "simple"
   ],
   "dependencies": {
+    "eslint-formatter-pretty": "^1.1.0",
     "gulp-eslint": "^3.0.1",
     "gulp-util": "^3.0.6",
     "through2": "^2.0.0",
@@ -56,6 +57,7 @@
   "devDependencies": {
     "ava": "*",
     "gulp": "^3.9.0",
+    "p-event": "^1.3.0",
     "vinyl-file": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "node": ">=4"
   },
   "scripts": {
-    "test": "xo --ignore='_fixture.js' && ava"
+    "test": "xo --ignore _fixture.js && ava"
   },
   "files": [
     "index.js"
@@ -48,6 +48,7 @@
     "simple"
   ],
   "dependencies": {
+    "gulp-eslint": "^3.0.1",
     "gulp-util": "^3.0.6",
     "through2": "^2.0.0",
     "xo": "^0.18.0"
@@ -55,7 +56,6 @@
   "devDependencies": {
     "ava": "*",
     "gulp": "^3.9.0",
-    "hooker": "^0.2.3",
     "vinyl-file": "^3.0.0"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -42,29 +42,17 @@ Default: `false`
 
 Report errors only.
 
-### xo.result(action)
+### [xo.result(action)](https://github.com/adametry/gulp-eslint/#eslintresultaction)
 
-See: https://github.com/adametry/gulp-eslint/#eslintresultaction
+### [xo.results(action)](https://github.com/adametry/gulp-eslint/#eslintresultsaction)
 
-### xo.results(action)
+### [xo.failOnError()](https://github.com/adametry/gulp-eslint/#eslintfailonerror)
 
-See: https://github.com/adametry/gulp-eslint/#eslintresultsaction
+### [xo.failAfterError()](https://github.com/adametry/gulp-eslint/#eslintfailaftererror)
 
-### xo.failOnError()
+### [xo.format(formatter, output)](https://github.com/adametry/gulp-eslint/#eslintformatformatter-output)
 
-See: https://github.com/adametry/gulp-eslint/#eslintfailonerror
-
-### xo.failAfterError()
-
-See: https://github.com/adametry/gulp-eslint/#eslintfailaftererror
-
-### xo.format(formatter, output)
-
-See: https://github.com/adametry/gulp-eslint/#eslintformatformatter-output
-
-### xo.formatEach(formatter, output)
-
-https://github.com/adametry/gulp-eslint/#eslintformateachformatter-output
+### [xo.formatEach(formatter, output)](https://github.com/adametry/gulp-eslint/#eslintformateachformatter-output)
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -23,7 +23,8 @@ const xo = require('gulp-xo');
 gulp.task('default', () =>
 	gulp.src('src/app.js')
 		.pipe(xo())
-		.pipe(gulp.dest('dist'))
+		.pipe(xo.format())
+		.pipe(xo.failAfterError())
 );
 ```
 
@@ -34,23 +35,36 @@ gulp.task('default', () =>
 
 #### options
 
-XO [options](https://github.com/sindresorhus/xo#config) can be specified in package.json.
-
-In the gulpfile you can specify the following options:
-
-##### reporter
-
-Type: `string`<br>
-Default: [`eslint-formatter-pretty`](https://github.com/sindresorhus/eslint-formatter-pretty)
-
-Any [ESLint reporter](http://eslint.org/docs/user-guide/command-line-interface#f---format).
-
 ##### quiet
 
 Type: `boolean`<br>
 Default: `false`
 
 Report errors only.
+
+### xo.result(action)
+
+See: https://github.com/adametry/gulp-eslint/#eslintresultaction
+
+### xo.results(action)
+
+See: https://github.com/adametry/gulp-eslint/#eslintresultsaction
+
+### xo.failOnError()
+
+See: https://github.com/adametry/gulp-eslint/#eslintfailonerror
+
+### xo.failAfterError()
+
+See: https://github.com/adametry/gulp-eslint/#eslintfailaftererror
+
+### xo.format(formatter, output)
+
+See: https://github.com/adametry/gulp-eslint/#eslintformatformatter-output
+
+### xo.formatEach(formatter, output)
+
+https://github.com/adametry/gulp-eslint/#eslintformateachformatter-output
 
 
 ## License

--- a/readme.md
+++ b/readme.md
@@ -42,22 +42,22 @@ Default: `false`
 
 Report errors only.
 
+### [xo.format(formatter, output)](https://github.com/adametry/gulp-eslint/#eslintformatformatter-output)
+
+### [xo.failAfterError()](https://github.com/adametry/gulp-eslint/#eslintfailaftererror)
+
+### [xo.failOnError()](https://github.com/adametry/gulp-eslint/#eslintfailonerror)
+
+### [xo.formatEach(formatter, output)](https://github.com/adametry/gulp-eslint/#eslintformateachformatter-output)
+
 ### [xo.result(action)](https://github.com/adametry/gulp-eslint/#eslintresultaction)
 
 ### [xo.results(action)](https://github.com/adametry/gulp-eslint/#eslintresultsaction)
 
-### [xo.failOnError()](https://github.com/adametry/gulp-eslint/#eslintfailonerror)
-
-### [xo.failAfterError()](https://github.com/adametry/gulp-eslint/#eslintfailaftererror)
-
-### [xo.format(formatter, output)](https://github.com/adametry/gulp-eslint/#eslintformatformatter-output)
-
-### [xo.formatEach(formatter, output)](https://github.com/adametry/gulp-eslint/#eslintformateachformatter-output)
-
 ## Related
 
-- [gulp-eslint](https://github.com/adametry/gulp-eslint)
-- [gulp-reporter](https://github.com/gucong3000/gulp-reporter)
+- [gulp-eslint](https://github.com/adametry/gulp-eslint): A gulp plugin for ESLint.
+- [gulp-reporter](https://github.com/gucong3000/gulp-reporter): Error report for: CSSLint, EditorConfig, ESLint, HTMLHint, JSCS, JSHint, PostCSS, TSLint, XO.
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -54,6 +54,10 @@ Report errors only.
 
 ### [xo.formatEach(formatter, output)](https://github.com/adametry/gulp-eslint/#eslintformateachformatter-output)
 
+## Related
+
+- [gulp-eslint](https://github.com/adametry/gulp-eslint)
+- [gulp-reporter](https://github.com/gucong3000/gulp-reporter)
 
 ## License
 

--- a/test.js
+++ b/test.js
@@ -1,24 +1,17 @@
 import test from 'ava';
 import vinylFile from 'vinyl-file';
-import hooker from 'hooker';
-import gutil from 'gulp-util';
 import xo from '.';
 
 test(t => {
-	t.plan(1);
-
 	const stream = xo();
-
-	hooker.hook(gutil, 'log', (...args) => {
-		const str = args.join(' ');
-
-		if (/camelcase/.test(str) && /no-unused-vars/.test(str)) {
-			hooker.unhook(gutil, 'log');
-			t.pass();
-		}
+	stream.on('data', file => {
+		t.truthy(file.eslint);
+		t.truthy(file.eslint.messages.length);
+		t.pass();
 	});
-
-	stream.on('error', () => ({}));
+	stream.on('error', () => {
+		t.fail();
+	});
 	stream.write(vinylFile.readSync('_fixture.js'));
 	stream.write(vinylFile.readSync('_fixture.js'));
 	stream.end();

--- a/test.js
+++ b/test.js
@@ -1,18 +1,30 @@
 import test from 'ava';
 import vinylFile from 'vinyl-file';
+import pEvent from 'p-event';
 import xo from '.';
 
-test(t => {
+test(async t => {
 	const stream = xo();
 	stream.on('data', file => {
 		t.truthy(file.eslint);
 		t.truthy(file.eslint.messages.length);
 		t.pass();
 	});
-	stream.on('error', () => {
-		t.fail();
-	});
+	const finish = pEvent(stream, 'finish');
 	stream.write(vinylFile.readSync('_fixture.js'));
 	stream.write(vinylFile.readSync('_fixture.js'));
 	stream.end();
+	await finish;
+});
+
+test('default formatter', async t => {
+	const stream = xo();
+	stream.pipe(xo.format(null, report => {
+		t.truthy(/[×✖]/.test(report));
+		t.pass();
+	}));
+	const finish = pEvent(stream, 'finish');
+	stream.write(vinylFile.readSync('_fixture.js'));
+	stream.end();
+	await finish;
 });


### PR DESCRIPTION
- Compatible with `gulp-reporter`, easy to assign errors by developer
- Compatible with `gulp-eslint`, #14